### PR TITLE
[Copy Author ID] Update MessageLoggerV2.plugin.js

### DIFF
--- a/Plugins/MessageLoggerV2/MessageLoggerV2.plugin.js
+++ b/Plugins/MessageLoggerV2/MessageLoggerV2.plugin.js
@@ -3656,6 +3656,15 @@ module.exports = class MessageLoggerV2 {
                 this.nodeModules.electron.clipboard.writeText(messageId); // todo: store electron or writeText somewhere?
                 this.showToast('Copied!', { type: 'success' });
               }
+            },
+            {
+              type: 'item',
+              label: 'Copy Author ID',
+              action: () => {
+                ZeresPluginLibrary.DiscordModules.ContextMenuActions.closeContextMenu();
+                this.nodeModules.electron.clipboard.writeText(message.author.id);
+                this.showToast('Copied!', { type: 'success' });
+              }
             }
           );
           ZeresPluginLibrary.DCM.openContextMenu(


### PR DESCRIPTION
Adds the ability to copy the author's user id within the context menu.
`Message Logs > Right Click a message > Copy Author ID`